### PR TITLE
fix: match routes in code to Apidocs

### DIFF
--- a/src/routes/auth/changepassword.ts
+++ b/src/routes/auth/changepassword.ts
@@ -8,7 +8,7 @@ import {
 const changePasswordRouter: Router = express.Router();
 
 /**
- * @api {patch} /changePassword Change a user's password
+ * @api {patch} /auth/changePassword Change a user's password
  *
  * @apiDescription This route allows a user to change their password by providing their current email, old password, and new password.
  * Passwords are securely hashed and salted before being stored.

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -6,8 +6,8 @@ import { changePasswordRouter } from './changepassword';
 const authRoutes: Router = express.Router();
 
 // Explicitly assign each router to its base path
-authRoutes.use('/login', signinRouter);
-authRoutes.use('/register', registerRouter);
-authRoutes.use('/changePassword', changePasswordRouter);
+authRoutes.use(signinRouter);
+authRoutes.use(registerRouter);
+authRoutes.use(changePasswordRouter);
 
 export { authRoutes };

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -28,7 +28,7 @@ const key = {
 };
 
 /**
- * @api {post} /login Request to sign a user in the system
+ * @api {post} /auth/login Request to sign a user in the system
  * @apiName PostLogin
  * @apiGroup Auth
  *

--- a/src/routes/auth/register.ts
+++ b/src/routes/auth/register.ts
@@ -178,7 +178,7 @@ const passwordMiddlewareCheck = (
 };
 
 /**
- * @api {post} /register Request to register a user
+ * @api {post} /auth/register Request to register a user
  *
  * @apiDescription Registers a new user. Password must:
  * - Be at least 10 characters long
@@ -219,7 +219,7 @@ const passwordMiddlewareCheck = (
  *
  */
 registerRouter.post(
-    '/',
+    '/register',
     emailMiddlewareCheck,
     phoneMiddlewareCheck,
     passwordMiddlewareCheck,

--- a/src/routes/closed/books.ts
+++ b/src/routes/closed/books.ts
@@ -117,7 +117,7 @@ function mwValidAuthor(
 }
 
 /**
- * @api {post} /books Create a new book
+ * @api {post} /closed/books Create a new book
  * @apiName CreateBook
  * @apiGroup Books (Closed)
  * @apiPermission authenticated
@@ -261,7 +261,7 @@ booksRouter.post('/', async (request: Request, response: Response) => {
 });
 
 /**
- * @api {get} /books/author/:author Retrieve books by author
+ * @api {get} /closed/books/author/:author Retrieve books by author
  *
  * @apiDescription Request to get books by a certain author. This will retrieve all books that the author wrote and co-wrote.
  *
@@ -379,7 +379,7 @@ booksRouter.get(
 );
 
 /**
- * @api {get} /books/isbn/:isbn Retrieve a book by ISBN
+ * @api {get} /closed/books/isbn/:isbn Retrieve a book by ISBN
  * @apiName GetBookByISBN
  * @apiGroup Books (Closed)
  * @apiPermission authenticated
@@ -502,7 +502,7 @@ booksRouter.get(
 );
 
 /**
- * @api {get} /books Retrieve all books (paginated)
+ * @api {get} /closed/books Retrieve all books (paginated)
  * @apiName GetAllBooks
  * @apiGroup Books (Closed)
  * @apiPermission authenticated
@@ -616,7 +616,7 @@ booksRouter.get('/', async (request: Request, response: Response) => {
 });
 
 /**
- * @api {get} /books/age Retrieve books by age (publication year)
+ * @api {get} /closed/books/age Retrieve books by age (publication year)
  * @apiName GetBooksByAge
  * @apiGroup Books (Closed)
  * @apiPermission authenticated
@@ -1356,7 +1356,7 @@ booksRouter.patch(
 );
 
 /**
- * @api {delete} /books/:isbn13 Delete a book by ISBN-13
+ * @api {delete} /closed/books/:isbn13 Delete a book by ISBN-13
  * @apiName DeleteBook
  * @apiGroup Books (Closed)
  * @apiPermission authenticated
@@ -1467,7 +1467,7 @@ booksRouter.get(
 );
 
 /**
- * @api {get} /books/:bookId/image Retrieve image of a book
+ * @api {get} /closed/books/:bookId/image Retrieve image of a book
  * @apiName GetBookImage
  * @apiGroup Books (Closed)
  * @apiPermission authenticated
@@ -1522,7 +1522,7 @@ booksRouter.get('/:bookId/image', async (req: Request, res: Response) => {
 );
 
 /**
- * @api {get} /books/:bookId/small-image Retrieve small image of a book
+ * @api {get} /closed/books/:bookId/small-image Retrieve small image of a book
  * @apiName GetBookSmallImage
  * @apiGroup Books (Closed)
  * @apiPermission authenticated
@@ -1577,7 +1577,7 @@ booksRouter.get('/:bookId/small-image', async (req: Request, res: Response) => {
 );
 
 /**
- * @api {get} /books/title/:title Fuzzy search books by title
+ * @api {get} /closed/books/title/:title Fuzzy search books by title
  * @apiName GetBooksByTitle
  * @apiGroup Books (Closed)
  * @apiPermission authenticated


### PR DESCRIPTION
Fix the issue of duplicate route naming in Apidocs in auth.

Adjust route naming in Apidocs to match the routes for books.